### PR TITLE
Fix #1 and use latest jade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ index.html
 test.html
 public/
 main.css
+node_modules

--- a/index.js
+++ b/index.js
@@ -3,7 +3,8 @@
 var fs = require('fs'),
     jade = require('jade'),
     url = require('url'),
-    join = require('path').join,
+    pathUtil = require('path'),
+    join = pathUtil.join,
     EventEmitter = require('events').EventEmitter;
 
 var templateCompiled = {};
@@ -37,10 +38,8 @@ JadeCompiler.prototype = {
                 return this.error(err);
             }
 
-            var script = jade.compile(jadeString, {client: true}),
-                from = this.paths.jadePath.lastIndexOf('/') + 1,
-                to = this.paths.jadePath.lastIndexOf('.'),
-                name = this.paths.jadePath.slice(from, to);
+            var script = jade.compileClient(jadeString),
+                name = pathUtil.basename(this.paths.jadePath).match(/^[^.]+/)[0].replace(/[^\w\d$_]/g,"_");
 
             script = '.' + name + ' = ' + script;
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
     "version": "0.1.0",
     "description": "Jade middelware precompiles Jade templates for functional execution in the browser",
     "main": "index.js",
+    "dependencies": {
+        "jade": "~1.3.1"
+    },
     "scripts": {
         "test": "mocha"
     },
@@ -23,7 +26,6 @@
     "license": "MIT",
     "devDependencies": {
         "sinon": "~1.7.3",
-        "jade": "~0.31.0",
         "express": "~3.2.6",
         "mocha": "~1.9.0",
         "chai": "~1.5.0",

--- a/test/dummyTemplates/t1.jade
+++ b/test/dummyTemplates/t1.jade
@@ -1,4 +1,4 @@
-doctype 5
+doctype html
 html
     meta(charset='utf-8')
     title test


### PR DESCRIPTION
Things I've done:
- Updated your `package.json` to include jade when depended on, this will prevent things from breaking if the jade the user is using is v2.x.x and there are overhauls.
- Updated the `name` from filepath algorithm to use regexes instead of `lastIndexOf` which apparently doesn't work on windows paths.
- included node_modules in the .gitignore
- fixed a test case which used the deprecated root of `html 5`
