### PR TITLE
Update compiler.js

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -35,7 +35,7 @@ JadeCompiler.prototype = {
         fs.readFile(this.paths.jadePath, 'utf8', function (err, jadeString) {
             if (err) return this.error(err);
 
-            var script = jade.compileClient(jadeString),
+            var script = jade.compileClient(jadeString, {filename:this.paths.jadePath}),
                 name = formatters[this.format](pathUtil.basename(this.paths.jadePath).match(/^[^.]+/)[0]);
 
             script = name + ' = ' + script;


### PR DESCRIPTION
Add "filename" option, so that "extends" in jade could be properly compiled.
